### PR TITLE
Fixed issue with total offer calculation for specific subjects and roles #38

### DIFF
--- a/src/models/offer.js
+++ b/src/models/offer.js
@@ -84,7 +84,7 @@ const offerSchema = new Schema(
 offerSchema.statics.calcTotalOffers = async function (category, subject, authorRole) {
   const categoryTotalOffersQty = await this.countDocuments({ authorRole })
   await Category.findByIdAndUpdate(category, { $set: { [`totalOffers.${authorRole}`]: categoryTotalOffersQty } }).exec()
-  const subjectTotalOffersQty = await this.countDocuments({ subject })
+  const subjectTotalOffersQty = await this.countDocuments({ subject, authorRole })
   await Subject.findByIdAndUpdate(subject, { $set: { [`totalOffers.${authorRole}`]: subjectTotalOffersQty } }).exec()
 }
 


### PR DESCRIPTION
Fixed issue with total offer calculation for specific subjects and roles:  Close #38
**Previously, totalOffers in subjects was calculated for all roles:**
<img width="1956" alt="Screenshot 2024-04-26 at 14 11 29" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/bcd5e6c8-d9e2-4e07-85de-52e60d496665">
_it included offers for both 'tutors' and 'students':_
<img width="1956" alt="Screenshot 2024-04-26 at 14 12 03" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/2c6a7528-c77c-4a9d-8d11-73a928575f54">

**Received the result after the changes:**
<img width="1844" alt="Screenshot 2024-04-26 at 14 16 53" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/a60e4ffd-121d-4011-9c21-2c8331642f9c">

Now, totalOffers in subjects are calculated separately for each role.


