### PR TITLE
Fixed issue with total offer calculation for specific categories and roles #39

### DIFF
--- a/src/models/offer.js
+++ b/src/models/offer.js
@@ -82,7 +82,7 @@ const offerSchema = new Schema(
 )
 
 offerSchema.statics.calcTotalOffers = async function (category, subject, authorRole) {
-  const categoryTotalOffersQty = await this.countDocuments({ authorRole })
+  const categoryTotalOffersQty = await this.countDocuments({ category, authorRole })
   await Category.findByIdAndUpdate(category, { $set: { [`totalOffers.${authorRole}`]: categoryTotalOffersQty } }).exec()
   const subjectTotalOffersQty = await this.countDocuments({ subject })
   await Subject.findByIdAndUpdate(subject, { $set: { [`totalOffers.${authorRole}`]: subjectTotalOffersQty } }).exec()


### PR DESCRIPTION
Fixed issue with total offer calculation for specific categories and roles: Close #39 
**Previously, totalOffers in categories was calculated for all categories:**
<img width="1441" alt="Screenshot 2024-04-26 at 15 24 12" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/a9ffb375-51cb-4f58-a928-799aa9cdd192">
<img width="1103" alt="Screenshot 2024-04-26 at 15 25 11" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/1c4082dd-8267-4930-98b0-9ea498e615ad">

Now, totalOffers in categories are calculated separately for each category and role.
**Received the result after the changes:**
<img width="1462" alt="Screenshot 2024-04-26 at 15 28 04" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/0c6fabaf-be0d-4989-a9f4-1e6e5654346c">
<img width="1458" alt="Screenshot 2024-04-26 at 15 28 38" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/1a9cc074-1c0d-42d3-b02d-c100a341f08b">
