### PR TITLE
Fixed issue with recalculating totalOffers value after deleting an offer #40

### DIFF
--- a/src/models/offer.js
+++ b/src/models/offer.js
@@ -92,4 +92,8 @@ offerSchema.post('save', async function (doc) {
   doc.constructor.calcTotalOffers(doc.category, doc.subject, doc.authorRole)
 })
 
+offerSchema.post('findOneAndRemove', async function (doc) {
+  doc.constructor.calcTotalOffers(doc.category, doc.subject, doc.authorRole);
+})
+
 module.exports = model(OFFER, offerSchema)


### PR DESCRIPTION
Added trigger to recalculate the totalOffer field in categories and subjects when an offer is deleted.
Previously, totalOffer calculation only occurred on the 'add offer' event. On the delete offer event, totalOffer remained unchanged:
<img width="1943" alt="Screenshot 2024-04-26 at 16 41 43" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/df4fe3c7-8778-4bdf-8085-baa608720bef">
<img width="1827" alt="Screenshot 2024-04-26 at 16 40 51" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/559b6866-8130-4979-b82d-f80d2a81dfd1">

Now, after deleting an offer, the count in the totalOffer field for categories and subjects is automatically updated:
<img width="1943" alt="Screenshot 2024-04-26 at 16 43 51" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/8b35bda3-21c1-439e-9f78-bd4fccae2365">
