### PR TITLE
Added validation for changing price and cooperation status simultaneously #45

### DIFF
--- a/src/services/cooperation.js
+++ b/src/services/cooperation.js
@@ -34,6 +34,10 @@ const cooperationService = {
 
     const cooperation = await Cooperation.findById(id)
 
+    if (updateData.hasOwnProperty('price') && updateData.hasOwnProperty('status')) {
+      throw createForbiddenError()
+    }
+
     if (price) {
       if (currentUserRole !== cooperation.needAction) {
         throw createForbiddenError()


### PR DESCRIPTION
Added validation for changing price and status of cooperation at the same time: Close #45 
Previously, when setting both price and status in the body and then updating a cooperation, this would update a cooperation:
<img width="1617" alt="Screenshot 2024-04-26 at 21 35 05" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/5cba4b4c-b119-47e1-aa24-27ae11f4137a">

After the change, **users receive a 'Forbidden' error** for this action:
<img width="1673" alt="Screenshot 2024-04-26 at 21 44 42" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/6b433b8a-a071-460e-a78d-f59237a71c67">
