### PR TITLE
Added populated 'author' fields in comments for POST and GET methods #44

### DIFF
--- a/src/models/comment.js
+++ b/src/models/comment.js
@@ -7,12 +7,12 @@ const {
 
 const commentSchema = new Schema(
   {
-    text: {
-      type: String
-    },
     author: {
       type: Schema.Types.ObjectId,
       ref: USER
+    },
+    text: {
+      type: String
     },
     authorRole: {
       type: String,

--- a/src/services/comment.js
+++ b/src/services/comment.js
@@ -4,11 +4,19 @@ const commentService = {
   addComment: async (data) => {
     const { text, author, authorRole, cooperationId } = data
 
-    return await Comment.create({ author, cooperation: cooperationId, text, authorRole })
+    const newComment = await Comment.create({ author, cooperation: cooperationId, text, authorRole })
+
+    return await Comment.findById({ _id: newComment._id })
+      .populate('author', 'firstName lastName')
+      .select('-authorRole')
+      .exec()
   },
 
   getComments: async (cooperationId, userId) => {
-    return await Comment.find({ cooperation: cooperationId, author: userId }).exec()
+    return await Comment.find({ cooperation: cooperationId, author: userId })
+      .populate('author', 'firstName lastName')
+      .select('-authorRole')
+      .exec()
   }
 }
 


### PR DESCRIPTION
Added populated 'author' fields in comments for POST and GET methods: Close #44 

Previously, when creating or retrieving comments, the JSON response format was received as follows:
<img width="1297" alt="Screenshot 2024-04-26 at 23 52 41" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/eb647441-4558-4ada-bcef-5e060cbf175e">

After the recent update, **when creating a comment**, the current comment is received _with populated author fields_:
<img width="1341" alt="Screenshot 2024-04-27 at 02 11 34" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/b375dac7-d488-4049-ad66-8cb2512fa696">

Additionally, **when getting a comment**, a list of all the user's own comments related to a specific cooperation is received, _with populated author fields_: 
<img width="1440" alt="Screenshot 2024-04-27 at 02 12 43" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/ea9215a6-1521-42c1-8736-2bc51ea4f46d">
