### PR TITLE
Fixed issue with third-party comments for a cooperation #43

### DIFF
--- a/src/services/comment.js
+++ b/src/services/comment.js
@@ -1,13 +1,25 @@
 const Comment = require('~/models/comment')
+const Cooperation = require('~/models/cooperation')
+const { createForbiddenError } = require('~/utils/errorsHelper')
 
 const commentService = {
   addComment: async (data) => {
     const { text, author, authorRole, cooperationId } = data
 
+    const { initiator, receiver } = await Cooperation.findById(cooperationId)
+    if (author !== initiator.toString() && author !== receiver.toString()) {
+      throw createForbiddenError()
+    }
+
     return await Comment.create({ author, cooperation: cooperationId, text, authorRole })
   },
 
   getComments: async (cooperationId, userId) => {
+    const { initiator, receiver } = await Cooperation.findById(cooperationId)
+    if (userId !== initiator.toString() && userId !== receiver.toString()) {
+      throw createForbiddenError()
+    }
+
     return await Comment.find({ cooperation: cooperationId, author: userId }).exec()
   }
 }


### PR DESCRIPTION
Resolved unauthorized access to comments for uninvolved users in cooperations: Close #43

Previously, when one user created a cooperation and created a comment on it:
![screen 1](https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/ad656fec-ba72-4ca6-80f0-e7f902dfe47c)
_any user not involved_ (neither as initiator nor receiver) _could create and access comments on a cooperation_ initiated by another user: 
![screen 2](https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/1219f4b1-6901-47a2-9cae-11004cb03322)

Now, **users not involved (neither as initiator nor receiver)** now receive a **Forbidden error** when attempting to access comments for cooperations initiated by other users: 
<img width="1438" alt="Screenshot 2024-04-28 at 15 48 47" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/193bac77-8b87-48a8-b701-d754c02e46d6">
and receive a **Forbidden error** when attempting to create comments for cooperations initiated by other users:
<img width="1438" alt="Screenshot 2024-04-28 at 15 53 41" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/4aaef110-d24a-4049-b912-0e39eb8953c3">
