### PR TITLE
Added population of MongoDB documents for "Subjects" upon database initialization #69

### DIFF
--- a/docs/category/category-schema.yaml
+++ b/docs/category/category-schema.yaml
@@ -1,35 +1,40 @@
 definitions:
   categories:
-    type: array
-    items:
-      type: object
-      properties:
-        _id:
-          type: string
-        name:
-          type: string
-        appearance:
+    type: object
+    properties:
+      items:
+        type: array
+        items:
           type: object
           properties:
-            icon:
+            _id:
               type: string
-            color:
+            name:
               type: string
-        totalOffers:
-          type: object
-          properties:
-            student:
-              type: number
-              default: 0
-            tutor:
-              type: number
-              default: 0
-        createdAt:
-          type: string
-          format: date-time
-        updatedAt:
-          type: string
-          format: date-time
+            appearance:
+              type: object
+              properties:
+                icon_path:
+                  type: string
+                color:
+                  type: string
+            totalOffers:
+              type: object
+              properties:
+                student:
+                  type: number
+                  default: 0
+                tutor:
+                  type: number
+                  default: 0
+            createdAt:
+              type: string
+              format: date-time
+            updatedAt:
+              type: string
+              format: date-time
+      count:
+        type: integer
   categoryBody:
     type: object
     properties:
@@ -38,7 +43,7 @@ definitions:
       appearance:
         type: object
         properties:
-          icon:
+          icon_path:
             type: string
           color:
             type: string
@@ -52,7 +57,7 @@ definitions:
       appearance:
         type: object
         properties:
-          icon:
+          icon_path:
             type: string
           color:
             type: string

--- a/docs/category/category.yaml
+++ b/docs/category/category.yaml
@@ -6,7 +6,7 @@ paths:
       tags:
         - Categories
       summary: Find all categories
-      description: Finds and returns an array with a list of categories
+      description: Finds and returns an array with a list of categories which have at least one subject
       produces:
         - application/json
       parameters:
@@ -32,23 +32,131 @@ paths:
             application/json:
               schema:
                 $ref: '#/definitions/categories'
-              example:
-                - _id: 64045f98b131dd04d7896af6
-                  name: languages
-                  categoryIcon:
-                    path: categories-icons/link-to-icon.png
-                    color: '#66c42c'
-                  totalOffers: { student: 10, tutor: 8 }
-                  createdAt: 2023-20-01T13:25:36.292Z
-                  updatedAt: 2023-20-01T13:25:36.292Z
-                - _id: 640461e3cfdda3f3d16dcac5
-                  name: music
-                  categoryIcon:
-                    path: categories-icons/link-to-icon.png
-                    color: '#66c42c'
-                  totalOffers: { student: 10, tutor: 8 }
-                  createdAt: 2023-20-01T13:25:36.292Z
-                  updatedAt: 2023-20-01T13:25:36.292Z
+              examples:
+                example1:
+                  value:
+                    items:
+                      - _id: 64884f7afdc2d1a130c24ace
+                        name: Painting
+                        appearance:
+                          icon_path: painting.svg
+                          color: '#79B260'
+                        totalOffers: { student: 0, tutor: 0 }
+                        createdAt: 2024-05-15T09:57:42.593Z
+                        updatedAt: 2024-05-15T09:57:42.593Z
+                      - _id: 64884f83fdc2d1a130c24ad0
+                        name: Finances
+                        appearance:
+                          icon_path: finances.svg
+                          color: '#F1BC17'
+                        totalOffers: { student: 0, tutor: 0 }
+                        createdAt: 2024-05-15T09:57:42.572Z
+                        updatedAt: 2024-05-15T09:57:42.572Z
+                      - _id: 64884fe3fdc2d1a130c24adc
+                        name: Psychology
+                        appearance:
+                          icon_path: psychology.svg
+                          color: '#CD4EAC'
+                        totalOffers: { student: 0, tutor: 0 }
+                        createdAt: 2024-05-15T09:57:42.370Z
+                        updatedAt: 2024-05-15T09:57:42.370Z
+                      - _id: 64884fc3fdc2d1a130c24ada
+                        name: Physics
+                        appearance:
+                          icon_path: physics.svg
+                          color: '#F18D17'
+                        totalOffers: { student: 0, tutor: 0 }
+                        createdAt: 2024-05-15T09:57:42.364Z
+                        updatedAt: 2024-05-15T09:57:42.364Z
+                      - _id: 64884fb0fdc2d1a130c24ad8
+                        name: Astronomy
+                        appearance:
+                          icon_path: astronomy.svg
+                          color: '#00A7A7'
+                        totalOffers: { student: 0, tutor: 0 }
+                        createdAt: 2024-05-15T09:57:42.358Z
+                        updatedAt: 2024-05-15T09:57:42.358Z
+                      - _id: 64884fa2fdc2d1a130c24ad6
+                        name: Chemistry
+                        appearance:
+                          icon_path: chemistry.svg
+                          color: '#B35969'
+                        totalOffers: { student: 0, tutor: 0 }
+                        createdAt: 2024-05-15T09:57:42.352Z
+                        updatedAt: 2024-05-15T09:57:42.352Z
+                      - _id: 64884f8efdc2d1a130c24ad2
+                        name: Marketing
+                        appearance:
+                          icon_path: marketing.svg
+                          color: '#1784F1'
+                        totalOffers: { student: 0, tutor: 0 }
+                        createdAt: 2024-05-15T09:57:42.345Z
+                        updatedAt: 2024-05-15T09:57:42.345Z
+                      - _id: 64884f98fdc2d1a130c24ad4
+                        name: Audit
+                        appearance:
+                          icon_path: audit.svg
+                          color: '#EF4F61'
+                        totalOffers: { student: 0, tutor: 0 }
+                        createdAt: 2024-05-15T09:57:42.341Z
+                        updatedAt: 2024-05-15T09:57:42.341Z
+                      - _id: 64884f70fdc2d1a130c24acc
+                        name: Biology
+                        appearance:
+                          icon_path: biology.svg
+                          color: '#5A8088'
+                        totalOffers: { student: 0, tutor: 0 }
+                        createdAt: 2024-05-15T09:57:42.337Z
+                        updatedAt: 2024-05-15T09:57:42.337Z
+                      - _id: 64884f66fdc2d1a130c24aca
+                        name: History
+                        appearance:
+                          icon_path: history.svg
+                          color: '#EF4257'
+                        totalOffers: { student: 0, tutor: 0 }
+                        createdAt: 2024-05-15T09:57:42.331Z
+                        updatedAt: 2024-05-15T09:57:42.331Z
+                      - _id: 64884f21fdc2d1a130c24ac0
+                        name: Languages
+                        appearance:
+                          icon_path: languages.svg
+                          color: '#7BB362'
+                        totalOffers: { student: 0, tutor: 0 }
+                        createdAt: 2024-05-15T09:57:42.326Z
+                        updatedAt: 2024-05-15T09:57:42.326Z
+                      - _id: 64884f59fdc2d1a130c24ac8
+                        name: Design
+                        appearance:
+                          icon_path: design.svg
+                          color: '#00A7A7'
+                        totalOffers: { student: 0, tutor: 0 }
+                        createdAt: 2024-05-15T09:57:42.319Z
+                        updatedAt: 2024-05-15T09:57:42.319Z
+                      - _id: 64884fedfdc2d1a130c24ade
+                        name: Computer science
+                        appearance:
+                          icon_path: computer_science.svg
+                          color: '#5A8088'
+                        totalOffers: { student: 0, tutor: 0 }
+                        createdAt: 2024-05-15T09:57:42.312Z
+                        updatedAt: 2024-05-15T09:57:42.312Z
+                      - _id: 64884f4dfdc2d1a130c24ac6
+                        name: Music
+                        appearance:
+                          icon_path: music.svg
+                          color: '#B35969'
+                        totalOffers: { student: 0, tutor: 0 }
+                        createdAt: 2024-05-15T09:57:42.309Z
+                        updatedAt: 2024-05-15T09:57:42.309Z
+                      - _id: 64884f33fdc2d1a130c24ac2
+                        name: Mathematics
+                        appearance:
+                          icon_path: mathematics.svg
+                          color: '#F2BE22'
+                        totalOffers: { student: 0, tutor: 0 }
+                        createdAt: 2024-05-15T09:57:42.301Z
+                        updatedAt: 2024-05-15T09:57:42.301Z
+                    count: 15
         401:
           description: Unauthorized
           content:

--- a/src/consts/subjects.js
+++ b/src/consts/subjects.js
@@ -1,0 +1,1188 @@
+const subjects = {
+  ALGEBRA: {
+    _id: '6644b9ee5b09bc63fa8300fd',
+    name: 'Algebra',
+    category: '64884f33fdc2d1a130c24ac2',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:34:38.926Z',
+    updatedAt: '2024-05-15T13:34:38.926Z'
+  },
+  CALCULUS: {
+    _id: '6644b9fe5b09bc63fa830100',
+    name: 'Calculus',
+    category: '64884f33fdc2d1a130c24ac2',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:34:54.092Z',
+    updatedAt: '2024-05-15T13:34:54.092Z'
+  },
+  GEOMETRY: {
+    _id: '6644ba0c5b09bc63fa830103',
+    name: 'Geometry',
+    category: '64884f33fdc2d1a130c24ac2',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:35:08.343Z',
+    updatedAt: '2024-05-15T13:35:08.343Z'
+  },
+  TRIGONOMETRY: {
+    _id: '6644ba165b09bc63fa830106',
+    name: 'Trigonometry',
+    category: '64884f33fdc2d1a130c24ac2',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:35:18.137Z',
+    updatedAt: '2024-05-15T13:35:18.137Z'
+  },
+  STATISTICS: {
+    _id: '6644ba215b09bc63fa830109',
+    name: 'Statistics',
+    category: '64884f33fdc2d1a130c24ac2',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:35:29.568Z',
+    updatedAt: '2024-05-15T13:35:29.568Z'
+  },
+  NUMBER_THEORY: {
+    _id: '6644ba2b5b09bc63fa83010c',
+    name: 'Number Theory',
+    category: '64884f33fdc2d1a130c24ac2',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:35:39.277Z',
+    updatedAt: '2024-05-15T13:35:39.277Z'
+  },
+  LINEAR_ALGEBRA: {
+    _id: '6644ba345b09bc63fa83010f',
+    name: 'Linear Algebra',
+    category: '64884f33fdc2d1a130c24ac2',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:35:48.829Z',
+    updatedAt: '2024-05-15T13:35:48.829Z'
+  },
+  DIFFERENTIAL_EQUATIONS: {
+    _id: '6644ba3d5b09bc63fa830112',
+    name: 'Differential Equations',
+    category: '64884f33fdc2d1a130c24ac2',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:35:57.864Z',
+    updatedAt: '2024-05-15T13:35:57.864Z'
+  },
+  DISCRETE_MATHEMATICS: {
+    _id: '6644ba475b09bc63fa830115',
+    name: 'Discrete Mathematics',
+    category: '64884f33fdc2d1a130c24ac2',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:36:07.009Z',
+    updatedAt: '2024-05-15T13:36:07.009Z'
+  },
+  MATHEMATICAL_LOGIC: {
+    _id: '6644ba505b09bc63fa830118',
+    name: 'Mathematical Logic',
+    category: '64884f33fdc2d1a130c24ac2',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:36:16.038Z',
+    updatedAt: '2024-05-15T13:36:16.038Z'
+  },
+  MUSIC_THEORY: {
+    _id: '6644ba625b09bc63fa83011b',
+    name: 'Music Theory',
+    category: '64884f4dfdc2d1a130c24ac6',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:36:34.162Z',
+    updatedAt: '2024-05-15T13:36:34.162Z'
+  },
+  PIANO: {
+    _id: '6644ba6c5b09bc63fa83011e',
+    name: 'Piano',
+    category: '64884f4dfdc2d1a130c24ac6',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:36:44.155Z',
+    updatedAt: '2024-05-15T13:36:44.155Z'
+  },
+  GUITAR: {
+    _id: '6644ba765b09bc63fa830121',
+    name: 'Guitar',
+    category: '64884f4dfdc2d1a130c24ac6',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:36:54.234Z',
+    updatedAt: '2024-05-15T13:36:54.234Z'
+  },
+  VIOLIN: {
+    _id: '6644ba7e5b09bc63fa830124',
+    name: 'Violin',
+    category: '64884f4dfdc2d1a130c24ac6',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:37:02.024Z',
+    updatedAt: '2024-05-15T13:37:02.024Z'
+  },
+  VOICE_TRAINING: {
+    _id: '6644ba875b09bc63fa830127',
+    name: 'Voice Training',
+    category: '64884f4dfdc2d1a130c24ac6',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:37:11.668Z',
+    updatedAt: '2024-05-15T13:37:11.668Z'
+  },
+  MUSIC_COMPOSITION: {
+    _id: '6644ba905b09bc63fa83012a',
+    name: 'Music Composition',
+    category: '64884f4dfdc2d1a130c24ac6',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:37:20.411Z',
+    updatedAt: '2024-05-15T13:37:20.411Z'
+  },
+  MUSIC_PRODUCTION: {
+    _id: '6644ba985b09bc63fa83012d',
+    name: 'Music Production',
+    category: '64884f4dfdc2d1a130c24ac6',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:37:28.386Z',
+    updatedAt: '2024-05-15T13:37:28.386Z'
+  },
+  MUSIC_HISTORY: {
+    _id: '6644baa15b09bc63fa830130',
+    name: 'Music History',
+    category: '64884f4dfdc2d1a130c24ac6',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:37:37.302Z',
+    updatedAt: '2024-05-15T13:37:37.302Z'
+  },
+  JAZZ_STUDIES: {
+    _id: '6644baa95b09bc63fa830133',
+    name: 'Jazz Studies',
+    category: '64884f4dfdc2d1a130c24ac6',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:37:45.285Z',
+    updatedAt: '2024-05-15T13:37:45.285Z'
+  },
+  ETHNOMUSICOLOGY: {
+    _id: '6644bab25b09bc63fa830136',
+    name: 'Ethnomusicology',
+    category: '64884f4dfdc2d1a130c24ac6',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:37:54.197Z',
+    updatedAt: '2024-05-15T13:37:54.197Z'
+  },
+  INTRODUCTION_TO_PROGRAMMING: {
+    _id: '6644baca5b09bc63fa830139',
+    name: 'Introduction to Programming',
+    category: '64884fedfdc2d1a130c24ade',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:38:18.371Z',
+    updatedAt: '2024-05-15T13:38:18.371Z'
+  },
+  DATA_STRUCTURES_AND_ALGORITHMS: {
+    _id: '6644bad75b09bc63fa83013c',
+    name: 'Data Structures and Algorithms',
+    category: '64884fedfdc2d1a130c24ade',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:38:31.805Z',
+    updatedAt: '2024-05-15T13:38:31.805Z'
+  },
+  COMPUTER_NETWORKS: {
+    _id: '6644bae05b09bc63fa83013f',
+    name: 'Computer Networks',
+    category: '64884fedfdc2d1a130c24ade',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:38:40.849Z',
+    updatedAt: '2024-05-15T13:38:40.849Z'
+  },
+  OPERATING_SYSTEMS: {
+    _id: '6644bae95b09bc63fa830142',
+    name: 'Operating Systems',
+    category: '64884fedfdc2d1a130c24ade',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:38:49.087Z',
+    updatedAt: '2024-05-15T13:38:49.087Z'
+  },
+  DATABASE_MANAGEMENT_SYSTEMS: {
+    _id: '6644baf15b09bc63fa830145',
+    name: 'Database Management Systems',
+    category: '64884fedfdc2d1a130c24ade',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:38:57.187Z',
+    updatedAt: '2024-05-15T13:38:57.187Z'
+  },
+  WEB_DEVELOPMENT: {
+    _id: '6644bafa5b09bc63fa830148',
+    name: 'Web Development',
+    category: '64884fedfdc2d1a130c24ade',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:39:06.664Z',
+    updatedAt: '2024-05-15T13:39:06.664Z'
+  },
+  SOFTWARE_ENGINEERING: {
+    _id: '6644bb025b09bc63fa83014b',
+    name: 'Software Engineering',
+    category: '64884fedfdc2d1a130c24ade',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:39:14.694Z',
+    updatedAt: '2024-05-15T13:39:14.694Z'
+  },
+  ARTIFICIAL_INTELLIGENCE: {
+    _id: '6644bb0a5b09bc63fa83014e',
+    name: 'Artificial Intelligence',
+    category: '64884fedfdc2d1a130c24ade',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:39:22.641Z',
+    updatedAt: '2024-05-15T13:39:22.641Z'
+  },
+  MACHINE_LEARNING: {
+    _id: '6644bb135b09bc63fa830151',
+    name: 'Machine Learning',
+    category: '64884fedfdc2d1a130c24ade',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:39:31.361Z',
+    updatedAt: '2024-05-15T13:39:31.361Z'
+  },
+  CYBERSECURITY: {
+    _id: '6644bb1b5b09bc63fa830154',
+    name: 'Cybersecurity',
+    category: '64884fedfdc2d1a130c24ade',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:39:39.406Z',
+    updatedAt: '2024-05-15T13:39:39.406Z'
+  },
+  GRAPHIC_DESIGN: {
+    _id: '6644bcf85b09bc63fa830169',
+    name: 'Graphic Design',
+    category: '64884f59fdc2d1a130c24ac8',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:47:36.068Z',
+    updatedAt: '2024-05-15T13:47:36.068Z'
+  },
+  WEB_DESIGN: {
+    _id: '6644bd095b09bc63fa83016c',
+    name: 'Web Design',
+    category: '64884f59fdc2d1a130c24ac8',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:47:53.805Z',
+    updatedAt: '2024-05-15T13:47:53.805Z'
+  },
+  UX_DESIGN: {
+    _id: '6644bd315b09bc63fa83016f',
+    name: 'User Experience (UX) Design',
+    category: '64884f59fdc2d1a130c24ac8',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:48:33.873Z',
+    updatedAt: '2024-05-15T13:48:33.873Z'
+  },
+  PRODUCT_DESIGN: {
+    _id: '6644bd495b09bc63fa830172',
+    name: 'Product Design',
+    category: '64884f59fdc2d1a130c24ac8',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:48:57.726Z',
+    updatedAt: '2024-05-15T13:48:57.726Z'
+  },
+  INTERIOR_DESIGN: {
+    _id: '6644bd525b09bc63fa830175',
+    name: 'Interior Design',
+    category: '64884f59fdc2d1a130c24ac8',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:49:06.823Z',
+    updatedAt: '2024-05-15T13:49:06.823Z'
+  },
+  FASHION_DESIGN: {
+    _id: '6644bd5e5b09bc63fa830178',
+    name: 'Fashion Design',
+    category: '64884f59fdc2d1a130c24ac8',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:49:18.377Z',
+    updatedAt: '2024-05-15T13:49:18.377Z'
+  },
+  INDUSTRIAL_DESIGN: {
+    _id: '6644bd685b09bc63fa83017b',
+    name: 'Industrial Design',
+    category: '64884f59fdc2d1a130c24ac8',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:49:28.634Z',
+    updatedAt: '2024-05-15T13:49:28.634Z'
+  },
+  MOTION_DESIGN: {
+    _id: '6644bd725b09bc63fa83017e',
+    name: 'Motion Design',
+    category: '64884f59fdc2d1a130c24ac8',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:49:38.158Z',
+    updatedAt: '2024-05-15T13:49:38.158Z'
+  },
+  DESIGN_THINKING: {
+    _id: '6644bd7b5b09bc63fa830181',
+    name: 'Design Thinking',
+    category: '64884f59fdc2d1a130c24ac8',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:49:47.326Z',
+    updatedAt: '2024-05-15T13:49:47.326Z'
+  },
+  TYPOGRAPHY: {
+    _id: '6644bd845b09bc63fa830184',
+    name: 'Typography',
+    category: '64884f59fdc2d1a130c24ac8',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:49:56.154Z',
+    updatedAt: '2024-05-15T13:49:56.154Z'
+  },
+  ANCIENT_HISTORY: {
+    _id: '6644be055b09bc63fa830187',
+    name: 'Ancient History',
+    category: '64884f66fdc2d1a130c24aca',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:52:05.413Z',
+    updatedAt: '2024-05-15T13:52:05.413Z'
+  },
+  MEDIEVAL_HISTORY: {
+    _id: '6644be105b09bc63fa83018a',
+    name: 'Medieval History',
+    category: '64884f66fdc2d1a130c24aca',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:52:16.350Z',
+    updatedAt: '2024-05-15T13:52:16.350Z'
+  },
+  MODERN_HISTORY: {
+    _id: '6644be1a5b09bc63fa83018d',
+    name: 'Modern History',
+    category: '64884f66fdc2d1a130c24aca',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:52:26.220Z',
+    updatedAt: '2024-05-15T13:52:26.220Z'
+  },
+  WORLD_HISTORY: {
+    _id: '6644be225b09bc63fa830190',
+    name: 'World History',
+    category: '64884f66fdc2d1a130c24aca',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:52:34.970Z',
+    updatedAt: '2024-05-15T13:52:34.970Z'
+  },
+  EUROPEAN_HISTORY: {
+    _id: '6644be2d5b09bc63fa830193',
+    name: 'European History',
+    category: '64884f66fdc2d1a130c24aca',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:52:45.121Z',
+    updatedAt: '2024-05-15T13:52:45.121Z'
+  },
+  AMERICAN_HISTORY: {
+    _id: '6644be375b09bc63fa830196',
+    name: 'American History',
+    category: '64884f66fdc2d1a130c24aca',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:52:55.193Z',
+    updatedAt: '2024-05-15T13:52:55.193Z'
+  },
+  ASIAN_HISTORY: {
+    _id: '6644be405b09bc63fa830199',
+    name: 'Asian History',
+    category: '64884f66fdc2d1a130c24aca',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:53:04.773Z',
+    updatedAt: '2024-05-15T13:53:04.773Z'
+  },
+  AFRICAN_HISTORY: {
+    _id: '6644be495b09bc63fa83019c',
+    name: 'African History',
+    category: '64884f66fdc2d1a130c24aca',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:53:13.164Z',
+    updatedAt: '2024-05-15T13:53:13.164Z'
+  },
+  MILITARY_HISTORY: {
+    _id: '6644be535b09bc63fa83019f',
+    name: 'Military History',
+    category: '64884f66fdc2d1a130c24aca',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:53:23.249Z',
+    updatedAt: '2024-05-15T13:53:23.249Z'
+  },
+  CULTURAL_HISTORY: {
+    _id: '6644be5d5b09bc63fa8301a2',
+    name: 'Cultural History',
+    category: '64884f66fdc2d1a130c24aca',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:53:33.956Z',
+    updatedAt: '2024-05-15T13:53:33.956Z'
+  },
+  ENGLISH: {
+    _id: '6644bf6b29705a44425ba443',
+    name: 'English',
+    category: '64884f21fdc2d1a130c24ac0',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:58:03.538Z',
+    updatedAt: '2024-05-15T13:58:03.538Z'
+  },
+  SPANISH: {
+    _id: '6644bf7a29705a44425ba446',
+    name: 'Spanish',
+    category: '64884f21fdc2d1a130c24ac0',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:58:18.650Z',
+    updatedAt: '2024-05-15T13:58:18.650Z'
+  },
+  FRENCH: {
+    _id: '6644bf8329705a44425ba449',
+    name: 'French',
+    category: '64884f21fdc2d1a130c24ac0',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:58:27.604Z',
+    updatedAt: '2024-05-15T13:58:27.604Z'
+  },
+  GERMAN: {
+    _id: '6644bf8f29705a44425ba44c',
+    name: 'German',
+    category: '64884f21fdc2d1a130c24ac0',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:58:39.346Z',
+    updatedAt: '2024-05-15T13:58:39.346Z'
+  },
+  CHINESE: {
+    _id: '6644bf9a29705a44425ba44f',
+    name: 'Chinese',
+    category: '64884f21fdc2d1a130c24ac0',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:58:50.609Z',
+    updatedAt: '2024-05-15T13:58:50.609Z'
+  },
+  JAPANESE: {
+    _id: '6644bfa429705a44425ba452',
+    name: 'Japanese',
+    category: '64884f21fdc2d1a130c24ac0',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:59:00.451Z',
+    updatedAt: '2024-05-15T13:59:00.451Z'
+  },
+  ARABIC: {
+    _id: '6644bfac29705a44425ba455',
+    name: 'Arabic',
+    category: '64884f21fdc2d1a130c24ac0',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:59:08.987Z',
+    updatedAt: '2024-05-15T13:59:08.987Z'
+  },
+  UKRAINIAN: {
+    _id: '6644bfb629705a44425ba458',
+    name: 'Ukrainian',
+    category: '64884f21fdc2d1a130c24ac0',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:59:18.218Z',
+    updatedAt: '2024-05-15T13:59:18.218Z'
+  },
+  ITALIAN: {
+    _id: '6644bfbf29705a44425ba45b',
+    name: 'Italian',
+    category: '64884f21fdc2d1a130c24ac0',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:59:27.092Z',
+    updatedAt: '2024-05-15T13:59:27.092Z'
+  },
+  PORTUGUESE: {
+    _id: '6644bfcb29705a44425ba45e',
+    name: 'Portuguese',
+    category: '64884f21fdc2d1a130c24ac0',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T13:59:39.657Z',
+    updatedAt: '2024-05-15T13:59:39.657Z'
+  },
+  CELL_BIOLOGY: {
+    _id: '6644c01929705a44425ba461',
+    name: 'Cell Biology',
+    category: '64884f70fdc2d1a130c24acc',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:00:57.148Z',
+    updatedAt: '2024-05-15T14:00:57.148Z'
+  },
+  GENETICS: {
+    _id: '6644c02129705a44425ba464',
+    name: 'Genetics',
+    category: '64884f70fdc2d1a130c24acc',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:01:05.252Z',
+    updatedAt: '2024-05-15T14:01:05.252Z'
+  },
+  ECOLOGY: {
+    _id: '6644c02929705a44425ba467',
+    name: 'Ecology',
+    category: '64884f70fdc2d1a130c24acc',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:01:13.550Z',
+    updatedAt: '2024-05-15T14:01:13.550Z'
+  },
+  ANATOMY: {
+    _id: '6644c03229705a44425ba46a',
+    name: 'Anatomy',
+    category: '64884f70fdc2d1a130c24acc',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:01:22.306Z',
+    updatedAt: '2024-05-15T14:01:22.306Z'
+  },
+  PHYSIOLOGY: {
+    _id: '6644c03c29705a44425ba46d',
+    name: 'Physiology',
+    category: '64884f70fdc2d1a130c24acc',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:01:32.127Z',
+    updatedAt: '2024-05-15T14:01:32.127Z'
+  },
+  MICROBIOLOGY: {
+    _id: '6644c04629705a44425ba470',
+    name: 'Microbiology',
+    category: '64884f70fdc2d1a130c24acc',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:01:42.741Z',
+    updatedAt: '2024-05-15T14:01:42.741Z'
+  },
+  EVOLUTIONARY_BIOLOGY: {
+    _id: '6644c04f29705a44425ba473',
+    name: 'Evolutionary Biology',
+    category: '64884f70fdc2d1a130c24acc',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:01:51.414Z',
+    updatedAt: '2024-05-15T14:01:51.414Z'
+  },
+  BOTANY: {
+    _id: '6644c05929705a44425ba476',
+    name: 'Botany',
+    category: '64884f70fdc2d1a130c24acc',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:02:01.198Z',
+    updatedAt: '2024-05-15T14:02:01.198Z'
+  },
+  ZOOLOGY: {
+    _id: '6644c06129705a44425ba479',
+    name: 'Zoology',
+    category: '64884f70fdc2d1a130c24acc',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:02:09.741Z',
+    updatedAt: '2024-05-15T14:02:09.741Z'
+  },
+  BIOCHEMISTRY: {
+    _id: '6644c06a29705a44425ba47c',
+    name: 'Biochemistry',
+    category: '64884f70fdc2d1a130c24acc',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:02:18.732Z',
+    updatedAt: '2024-05-15T14:02:18.732Z'
+  },
+  DIGITAL_MARKETING: {
+    _id: '6644c08c29705a44425ba47f',
+    name: 'Digital Marketing',
+    category: '64884f8efdc2d1a130c24ad2',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:02:52.193Z',
+    updatedAt: '2024-05-15T14:02:52.193Z'
+  },
+  SOCIAL_MEDIA_MARKETING: {
+    _id: '6644c09429705a44425ba482',
+    name: 'Social Media Marketing',
+    category: '64884f8efdc2d1a130c24ad2',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:03:00.076Z',
+    updatedAt: '2024-05-15T14:03:00.076Z'
+  },
+  CONTENT_MARKETING: {
+    _id: '6644c09c29705a44425ba485',
+    name: 'Content Marketing',
+    category: '64884f8efdc2d1a130c24ad2',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:03:08.979Z',
+    updatedAt: '2024-05-15T14:03:08.979Z'
+  },
+  BRAND_MANAGEMENT: {
+    _id: '6644c0a429705a44425ba488',
+    name: 'Brand Management',
+    category: '64884f8efdc2d1a130c24ad2',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:03:16.847Z',
+    updatedAt: '2024-05-15T14:03:16.847Z'
+  },
+  MARKET_RESEARCH: {
+    _id: '6644c0ac29705a44425ba48b',
+    name: 'Market Research',
+    category: '64884f8efdc2d1a130c24ad2',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:03:24.919Z',
+    updatedAt: '2024-05-15T14:03:24.919Z'
+  },
+  ADVERTISING: {
+    _id: '6644c0b429705a44425ba48e',
+    name: 'Advertising',
+    category: '64884f8efdc2d1a130c24ad2',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:03:32.631Z',
+    updatedAt: '2024-05-15T14:03:32.631Z'
+  },
+  PUBLIC_RELATIONS: {
+    _id: '6644c0bd29705a44425ba491',
+    name: 'Public Relations',
+    category: '64884f8efdc2d1a130c24ad2',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:03:41.815Z',
+    updatedAt: '2024-05-15T14:03:41.815Z'
+  },
+  SALES_MANAGEMENT: {
+    _id: '6644c0c629705a44425ba494',
+    name: 'Sales Management',
+    category: '64884f8efdc2d1a130c24ad2',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:03:50.372Z',
+    updatedAt: '2024-05-15T14:03:50.372Z'
+  },
+  CONSUMER_BEHAVIOR: {
+    _id: '6644c0ce29705a44425ba497',
+    name: 'Consumer Behavior',
+    category: '64884f8efdc2d1a130c24ad2',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:03:58.941Z',
+    updatedAt: '2024-05-15T14:03:58.941Z'
+  },
+  MARKETING_ANALYTICS: {
+    _id: '6644c0d729705a44425ba49a',
+    name: 'Marketing Analytics',
+    category: '64884f8efdc2d1a130c24ad2',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:04:07.439Z',
+    updatedAt: '2024-05-15T14:04:07.439Z'
+  },
+  FINANCIAL_AUDIT: {
+    _id: '6644c0e429705a44425ba49d',
+    name: 'Financial Audit',
+    category: '64884f98fdc2d1a130c24ad4',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:04:20.581Z',
+    updatedAt: '2024-05-15T14:04:20.581Z'
+  },
+  OPERATIONAL_AUDIT: {
+    _id: '6644c0ed29705a44425ba4a0',
+    name: 'Operational Audit',
+    category: '64884f98fdc2d1a130c24ad4',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:04:29.466Z',
+    updatedAt: '2024-05-15T14:04:29.466Z'
+  },
+  INTERNAL_AUDIT: {
+    _id: '6644c0f529705a44425ba4a3',
+    name: 'Internal Audit',
+    category: '64884f98fdc2d1a130c24ad4',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:04:37.081Z',
+    updatedAt: '2024-05-15T14:04:37.081Z'
+  },
+  EXTERNAL_AUDIT: {
+    _id: '6644c0fc29705a44425ba4a6',
+    name: 'External Audit',
+    category: '64884f98fdc2d1a130c24ad4',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:04:44.571Z',
+    updatedAt: '2024-05-15T14:04:44.571Z'
+  },
+  IT_AUDIT: {
+    _id: '6644c10529705a44425ba4a9',
+    name: 'IT Audit',
+    category: '64884f98fdc2d1a130c24ad4',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:04:53.214Z',
+    updatedAt: '2024-05-15T14:04:53.214Z'
+  },
+  TAX_AUDIT: {
+    _id: '6644c10d29705a44425ba4ac',
+    name: 'Tax Audit',
+    category: '64884f98fdc2d1a130c24ad4',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:05:01.201Z',
+    updatedAt: '2024-05-15T14:05:01.201Z'
+  },
+  FORENSIC_AUDIT: {
+    _id: '6644c11329705a44425ba4af',
+    name: 'Forensic Audit',
+    category: '64884f98fdc2d1a130c24ad4',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:05:08.000Z',
+    updatedAt: '2024-05-15T14:05:08.000Z'
+  },
+  COMPLIANCE_AUDIT: {
+    _id: '6644c11b29705a44425ba4b2',
+    name: 'Compliance Audit',
+    category: '64884f98fdc2d1a130c24ad4',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:05:15.782Z',
+    updatedAt: '2024-05-15T14:05:15.782Z'
+  },
+  ENVIRONMENTAL_AUDIT: {
+    _id: '6644c12329705a44425ba4b5',
+    name: 'Environmental Audit',
+    category: '64884f98fdc2d1a130c24ad4',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:05:23.955Z',
+    updatedAt: '2024-05-15T14:05:23.955Z'
+  },
+  QUALITY_AUDIT: {
+    _id: '6644c12f29705a44425ba4b8',
+    name: 'Quality Audit',
+    category: '64884f98fdc2d1a130c24ad4',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:05:35.062Z',
+    updatedAt: '2024-05-15T14:05:35.062Z'
+  },
+  ORGANIC_CHEMISTRY: {
+    _id: '6644c17029705a44425ba4bb',
+    name: 'Organic Chemistry',
+    category: '64884fa2fdc2d1a130c24ad6',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:06:40.992Z',
+    updatedAt: '2024-05-15T14:06:40.992Z'
+  },
+  INORGANIC_CHEMISTRY: {
+    _id: '6644c17829705a44425ba4be',
+    name: 'Inorganic Chemistry',
+    category: '64884fa2fdc2d1a130c24ad6',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:06:48.789Z',
+    updatedAt: '2024-05-15T14:06:48.789Z'
+  },
+  PHYSICAL_CHEMISTRY: {
+    _id: '6644c18229705a44425ba4c1',
+    name: 'Physical Chemistry',
+    category: '64884fa2fdc2d1a130c24ad6',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:06:58.413Z',
+    updatedAt: '2024-05-15T14:06:58.413Z'
+  },
+  ANALYTICAL_CHEMISTRY: {
+    _id: '6644c18b29705a44425ba4c4',
+    name: 'Analytical Chemistry',
+    category: '64884fa2fdc2d1a130c24ad6',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:07:07.055Z',
+    updatedAt: '2024-05-15T14:07:07.055Z'
+  },
+  POLYMER_CHEMISTRY: {
+    _id: '6644c19b29705a44425ba4ca',
+    name: 'Polymer Chemistry',
+    category: '64884fa2fdc2d1a130c24ad6',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:07:23.039Z',
+    updatedAt: '2024-05-15T14:07:23.039Z'
+  },
+  MEDICINAL_CHEMISTRY: {
+    _id: '6644c1a329705a44425ba4cd',
+    name: 'Medicinal Chemistry',
+    category: '64884fa2fdc2d1a130c24ad6',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:07:31.947Z',
+    updatedAt: '2024-05-15T14:07:31.947Z'
+  },
+  ENVIRONMENTAL_CHEMISTRY: {
+    _id: '6644c1ad29705a44425ba4d0',
+    name: 'Environmental Chemistry',
+    category: '64884fa2fdc2d1a130c24ad6',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:07:41.376Z',
+    updatedAt: '2024-05-15T14:07:41.376Z'
+  },
+  NUCLEAR_CHEMISTRY: {
+    _id: '6644c1ba29705a44425ba4d3',
+    name: 'Nuclear Chemistry',
+    category: '64884fa2fdc2d1a130c24ad6',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:07:54.898Z',
+    updatedAt: '2024-05-15T14:07:54.898Z'
+  },
+  THEORETICAL_CHEMISTRY: {
+    _id: '6644c1c329705a44425ba4d6',
+    name: 'Theoretical Chemistry',
+    category: '64884fa2fdc2d1a130c24ad6',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:08:03.389Z',
+    updatedAt: '2024-05-15T14:08:03.389Z'
+  },
+  OBSERVATIONAL_ASTRONOMY: {
+    _id: '6644c1ce29705a44425ba4d9',
+    name: 'Observational Astronomy',
+    category: '64884fb0fdc2d1a130c24ad8',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:08:14.132Z',
+    updatedAt: '2024-05-15T14:08:14.132Z'
+  },
+  ASTROPHYSICS: {
+    _id: '6644c1d629705a44425ba4dc',
+    name: 'Astrophysics',
+    category: '64884fb0fdc2d1a130c24ad8',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:08:22.788Z',
+    updatedAt: '2024-05-15T14:08:22.788Z'
+  },
+  COSMOLOGY: {
+    _id: '6644c1df29705a44425ba4df',
+    name: 'Cosmology',
+    category: '64884fb0fdc2d1a130c24ad8',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:08:31.402Z',
+    updatedAt: '2024-05-15T14:08:31.402Z'
+  },
+  PLANETARY_SCIENCE: {
+    _id: '6644c1e729705a44425ba4e2',
+    name: 'Planetary Science',
+    category: '64884fb0fdc2d1a130c24ad8',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:08:39.443Z',
+    updatedAt: '2024-05-15T14:08:39.443Z'
+  },
+  STELLAR_ASTRONOMY: {
+    _id: '6644c1ef29705a44425ba4e5',
+    name: 'Stellar Astronomy',
+    category: '64884fb0fdc2d1a130c24ad8',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:08:47.466Z',
+    updatedAt: '2024-05-15T14:08:47.466Z'
+  },
+  GALACTIC_ASTRONOMY: {
+    _id: '6644c1f929705a44425ba4e8',
+    name: 'Galactic Astronomy',
+    category: '64884fb0fdc2d1a130c24ad8',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:08:57.245Z',
+    updatedAt: '2024-05-15T14:08:57.245Z'
+  },
+  HIGH_ENERGY_ASTROPHYSICS: {
+    _id: '6644c20129705a44425ba4eb',
+    name: 'High-energy Astrophysics',
+    category: '64884fb0fdc2d1a130c24ad8',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:09:05.008Z',
+    updatedAt: '2024-05-15T14:09:05.008Z'
+  },
+  SOLAR_ASTRONOMY: {
+    _id: '6644c20a29705a44425ba4ee',
+    name: 'Solar Astronomy',
+    category: '64884fb0fdc2d1a130c24ad8',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:09:14.422Z',
+    updatedAt: '2024-05-15T14:09:14.422Z'
+  },
+  RADIO_ASTRONOMY: {
+    _id: '6644c22229705a44425ba4f1',
+    name: 'Radio Astronomy',
+    category: '64884fb0fdc2d1a130c24ad8',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:09:38.606Z',
+    updatedAt: '2024-05-15T14:09:38.606Z'
+  },
+  GRAVITATIONAL_ASTRONOMY: {
+    _id: '6644c22729705a44425ba4f4',
+    name: 'Gravitational Astronomy',
+    category: '64884fb0fdc2d1a130c24ad8',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:09:43.254Z',
+    updatedAt: '2024-05-15T14:09:43.254Z'
+  },
+  CLASSICAL_MECHANICS: {
+    _id: '6644c2c829705a44425ba4fd',
+    name: 'Classical Mechanics',
+    category: '64884fc3fdc2d1a130c24ada',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:12:24.773Z',
+    updatedAt: '2024-05-15T14:12:24.773Z'
+  },
+  QUANTUM_MECHANICS: {
+    _id: '6644c2d129705a44425ba500',
+    name: 'Quantum Mechanics',
+    category: '64884fc3fdc2d1a130c24ada',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:12:33.210Z',
+    updatedAt: '2024-05-15T14:12:33.210Z'
+  },
+  THERMODYNAMICS: {
+    _id: '6644c2d929705a44425ba503',
+    name: 'Thermodynamics',
+    category: '64884fc3fdc2d1a130c24ada',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:12:41.202Z',
+    updatedAt: '2024-05-15T14:12:41.202Z'
+  },
+  ELECTROMAGNETISM: {
+    _id: '6644c2e129705a44425ba506',
+    name: 'Electromagnetism',
+    category: '64884fc3fdc2d1a130c24ada',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:12:49.128Z',
+    updatedAt: '2024-05-15T14:12:49.128Z'
+  },
+  OPTICS: {
+    _id: '6644c2ea29705a44425ba509',
+    name: 'Optics',
+    category: '64884fc3fdc2d1a130c24ada',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:12:58.222Z',
+    updatedAt: '2024-05-15T14:12:58.222Z'
+  },
+  NUCLEAR_PHYSICS: {
+    _id: '6644c2f329705a44425ba50c',
+    name: 'Nuclear Physics',
+    category: '64884fc3fdc2d1a130c24ada',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:13:07.220Z',
+    updatedAt: '2024-05-15T14:13:07.220Z'
+  },
+  PARTICLE_PHYSICS: {
+    _id: '6644c2fc29705a44425ba50f',
+    name: 'Particle Physics',
+    category: '64884fc3fdc2d1a130c24ada',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:13:16.308Z',
+    updatedAt: '2024-05-15T14:13:16.308Z'
+  },
+  FLUID_DYNAMICS: {
+    _id: '6644c30e29705a44425ba515',
+    name: 'Fluid Dynamics',
+    category: '64884fc3fdc2d1a130c24ada',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:13:34.083Z',
+    updatedAt: '2024-05-15T14:13:34.083Z'
+  },
+  SOLID_STATE_PHYSICS: {
+    _id: '6644c31729705a44425ba518',
+    name: 'Solid State Physics',
+    category: '64884fc3fdc2d1a130c24ada',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:13:43.103Z',
+    updatedAt: '2024-05-15T14:13:43.103Z'
+  },
+  CLINICAL_PSYCHOLOGY: {
+    _id: '6644c3b429705a44425ba522',
+    name: 'Clinical Psychology',
+    category: '64884fe3fdc2d1a130c24adc',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:16:20.574Z',
+    updatedAt: '2024-05-15T14:16:20.574Z'
+  },
+  COGNITIVE_PSYCHOLOGY: {
+    _id: '6644c3bd29705a44425ba525',
+    name: 'Cognitive Psychology',
+    category: '64884fe3fdc2d1a130c24adc',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:16:29.628Z',
+    updatedAt: '2024-05-15T14:16:29.628Z'
+  },
+  DEVELOPMENTAL_PSYCHOLOGY: {
+    _id: '6644c3c629705a44425ba528',
+    name: 'Developmental Psychology',
+    category: '64884fe3fdc2d1a130c24adc',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:16:38.823Z',
+    updatedAt: '2024-05-15T14:16:38.823Z'
+  },
+  SOCIAL_PSYCHOLOGY: {
+    _id: '6644c3d029705a44425ba52b',
+    name: 'Social Psychology',
+    category: '64884fe3fdc2d1a130c24adc',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:16:48.334Z',
+    updatedAt: '2024-05-15T14:16:48.334Z'
+  },
+  EXPERIMENTAL_PSYCHOLOGY: {
+    _id: '6644c3d929705a44425ba52e',
+    name: 'Experimental Psychology',
+    category: '64884fe3fdc2d1a130c24adc',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:16:57.378Z',
+    updatedAt: '2024-05-15T14:16:57.378Z'
+  },
+  INDUSTRIAL_ORGANIZATIONAL_PSYCHOLOGY: {
+    _id: '6644c3e529705a44425ba531',
+    name: 'Industrial-Organizational Psychology',
+    category: '64884fe3fdc2d1a130c24adc',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:17:09.886Z',
+    updatedAt: '2024-05-15T14:17:09.886Z'
+  },
+  EDUCATIONAL_PSYCHOLOGY: {
+    _id: '6644c3f029705a44425ba534',
+    name: 'Educational Psychology',
+    category: '64884fe3fdc2d1a130c24adc',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:17:20.290Z',
+    updatedAt: '2024-05-15T14:17:20.290Z'
+  },
+  HEALTH_PSYCHOLOGY: {
+    _id: '6644c3f929705a44425ba537',
+    name: 'Health Psychology',
+    category: '64884fe3fdc2d1a130c24adc',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:17:29.624Z',
+    updatedAt: '2024-05-15T14:17:29.624Z'
+  },
+  FORENSIC_PSYCHOLOGY: {
+    _id: '6644c40329705a44425ba53a',
+    name: 'Forensic Psychology',
+    category: '64884fe3fdc2d1a130c24adc',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:17:39.024Z',
+    updatedAt: '2024-05-15T14:17:39.024Z'
+  },
+  NEUROPSYCHOLOGY: {
+    _id: '6644c40a29705a44425ba53d',
+    name: 'Neuropsychology',
+    category: '64884fe3fdc2d1a130c24adc',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:17:46.958Z',
+    updatedAt: '2024-05-15T14:17:46.958Z'
+  },
+  PERSONAL_FINANCE: {
+    _id: '6644c47c29705a44425ba540',
+    name: 'Personal Finance',
+    category: '64884f83fdc2d1a130c24ad0',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:19:40.438Z',
+    updatedAt: '2024-05-15T14:19:40.438Z'
+  },
+  CORPORATE_FINANCE: {
+    _id: '6644c48429705a44425ba543',
+    name: 'Corporate Finance',
+    category: '64884f83fdc2d1a130c24ad0',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:19:48.155Z',
+    updatedAt: '2024-05-15T14:19:48.155Z'
+  },
+  INVESTMENTS: {
+    _id: '6644c48c29705a44425ba546',
+    name: 'Investments',
+    category: '64884f83fdc2d1a130c24ad0',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:19:56.752Z',
+    updatedAt: '2024-05-15T14:19:56.752Z'
+  },
+  FINANCIAL_MARKETS: {
+    _id: '6644c49629705a44425ba549',
+    name: 'Financial Markets',
+    category: '64884f83fdc2d1a130c24ad0',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:20:06.232Z',
+    updatedAt: '2024-05-15T14:20:06.232Z'
+  },
+  ACCOUNTING: {
+    _id: '6644c49d29705a44425ba54c',
+    name: 'Accounting',
+    category: '64884f83fdc2d1a130c24ad0',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:20:13.911Z',
+    updatedAt: '2024-05-15T14:20:13.911Z'
+  },
+  RISK_MANAGEMENT: {
+    _id: '6644c4aa29705a44425ba54f',
+    name: 'Risk Management',
+    category: '64884f83fdc2d1a130c24ad0',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:20:26.298Z',
+    updatedAt: '2024-05-15T14:20:26.298Z'
+  },
+  FINANCIAL_ANALYSIS: {
+    _id: '6644c4b329705a44425ba552',
+    name: 'Financial Analysis',
+    category: '64884f83fdc2d1a130c24ad0',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:20:35.646Z',
+    updatedAt: '2024-05-15T14:20:35.646Z'
+  },
+  ECONOMICS: {
+    _id: '6644c4bc29705a44425ba555',
+    name: 'Economics',
+    category: '64884f83fdc2d1a130c24ad0',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:20:44.942Z',
+    updatedAt: '2024-05-15T14:20:44.942Z'
+  },
+  FINANCIAL_PLANNING: {
+    _id: '6644c4c529705a44425ba558',
+    name: 'Financial Planning',
+    category: '64884f83fdc2d1a130c24ad0',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:20:53.907Z',
+    updatedAt: '2024-05-15T14:20:53.907Z'
+  },
+  INTERNATIONAL_FINANCE: {
+    _id: '6644c4d129705a44425ba55b',
+    name: 'International Finance',
+    category: '64884f83fdc2d1a130c24ad0',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:21:05.489Z',
+    updatedAt: '2024-05-15T14:21:05.489Z'
+  },
+  OIL_PAINTING: {
+    _id: '6644c4d929705a44425ba55e',
+    name: 'Oil Painting',
+    category: '64884f7afdc2d1a130c24ace',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:21:13.202Z',
+    updatedAt: '2024-05-15T14:21:13.202Z'
+  },
+  WATERCOLOR_PAINTING: {
+    _id: '6644c4e129705a44425ba561',
+    name: 'Watercolor Painting',
+    category: '64884f7afdc2d1a130c24ace',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:21:21.624Z',
+    updatedAt: '2024-05-15T14:21:21.624Z'
+  },
+  ACRYLIC_PAINTING: {
+    _id: '6644c4ea29705a44425ba564',
+    name: 'Acrylic Painting',
+    category: '64884f7afdc2d1a130c24ace',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:21:30.155Z',
+    updatedAt: '2024-05-15T14:21:30.155Z'
+  },
+  PASTEL_PAINTING: {
+    _id: '6644c4f329705a44425ba567',
+    name: 'Pastel Painting',
+    category: '64884f7afdc2d1a130c24ace',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:21:39.252Z',
+    updatedAt: '2024-05-15T14:21:39.252Z'
+  },
+  MIXED_MEDIA_PAINTING: {
+    _id: '6644c4fd29705a44425ba56a',
+    name: 'Mixed Media Painting',
+    category: '64884f7afdc2d1a130c24ace',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:21:49.205Z',
+    updatedAt: '2024-05-15T14:21:49.205Z'
+  },
+  PORTRAIT_PAINTING: {
+    _id: '6644c50529705a44425ba56d',
+    name: 'Portrait Painting',
+    category: '64884f7afdc2d1a130c24ace',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:21:57.654Z',
+    updatedAt: '2024-05-15T14:21:57.654Z'
+  },
+  LANDSCAPE_PAINTING: {
+    _id: '6644c50e29705a44425ba570',
+    name: 'Landscape Painting',
+    category: '64884f7afdc2d1a130c24ace',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:22:06.737Z',
+    updatedAt: '2024-05-15T14:22:06.737Z'
+  },
+  STILL_LIFE_PAINTING: {
+    _id: '6644c51729705a44425ba573',
+    name: 'Still Life Painting',
+    category: '64884f7afdc2d1a130c24ace',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:22:15.453Z',
+    updatedAt: '2024-05-15T14:22:15.453Z'
+  },
+  ABSTRACT_PAINTING: {
+    _id: '6644c52029705a44425ba576',
+    name: 'Abstract Painting',
+    category: '64884f7afdc2d1a130c24ace',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:22:24.287Z',
+    updatedAt: '2024-05-15T14:22:24.287Z'
+  },
+  REALISTIC_PAINTING: {
+    _id: '6644c52829705a44425ba579',
+    name: 'Realistic Painting',
+    category: '64884f7afdc2d1a130c24ace',
+    totalOffers: { student: 0, tutor: 0 },
+    createdAt: '2024-05-15T14:22:32.540Z',
+    updatedAt: '2024-05-15T14:22:32.540Z'
+  }
+}
+
+module.exports = subjects

--- a/src/initialization/serverSetup.js
+++ b/src/initialization/serverSetup.js
@@ -1,6 +1,7 @@
 const databaseInitialization = require('~/initialization/database')
 const checkUserExistence = require('~/seed/checkUserExistence')
 const checkCategoryExistence = require('~/seed/checkCategoryExistence')
+const checkSubjectExistence = require('~/seed/checkSubjectExistence')
 const initialization = require('~/initialization/initialization')
 const logger = require('~/logger/logger')
 const {
@@ -12,6 +13,7 @@ const serverSetup = async (app) => {
   await databaseInitialization()
   await checkUserExistence()
   await checkCategoryExistence()
+  await checkSubjectExistence()
   initialization(app)
   return app.listen(SERVER_PORT, () => {
     logger.info(`Server is running on port ${SERVER_PORT}`)

--- a/src/seed/checkSubjectExistence.js
+++ b/src/seed/checkSubjectExistence.js
@@ -1,0 +1,24 @@
+const Subject = require('~/models/subject')
+const subjects = require('~/consts/subjects')
+const SeedSubject = require('~/seed/seedSubject')
+const logger = require('~/logger/logger')
+
+const checkSubjectExistence = async () => {
+  try {
+    await Promise.all(
+      Object.values(subjects).map(async (subject) => {
+        const isSubjectExist = await Subject.exists({ name: subject.name })
+
+        if (isSubjectExist) {
+          return
+        }
+
+        return await SeedSubject.createSubject(subject)
+      })
+    )
+  } catch (err) {
+    logger.error(err)
+  }
+}
+
+module.exports = checkSubjectExistence

--- a/src/seed/seedSubject.js
+++ b/src/seed/seedSubject.js
@@ -1,0 +1,14 @@
+const Subject = require('~/models/subject')
+const logger = require('~/logger/logger')
+
+const SeedSubject = {
+  createSubject: async (subject) => {
+    try {
+      return await Subject.create(subject)
+    } catch (err) {
+      logger.error(err)
+    }
+  }
+}
+
+module.exports = SeedSubject


### PR DESCRIPTION
### Added population of MongoDB documents for "`Subjects`" upon database initialization and fixed **Swagger** documentation for the `GET /categories` endpoint [ Close #69 ]

**Before population** of MongoDB documents for "`Subjects`":
<img width="1404" alt="Screenshot 2024-05-15 at 15 59 52" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/a2cd9577-10ce-4679-a258-73b8484f8247">

**After  population** of MongoDB documents for "`Subjects`":
<img width="1421" alt="Screenshot 2024-05-15 at 20 38 12" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/cfabdec5-4014-4984-a163-e7b1fb150f19">

**Updated data** in MongoDB documents for "`Subjects`":
<img width="1499" alt="Screenshot 2024-05-15 at 20 39 51" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/cda24cef-f0de-4026-99da-f6e2ccc070e1">

