### PR TITLE
Fixed bug when updating user's native language #74

### DIFF
--- a/src/consts/validation.js
+++ b/src/consts/validation.js
@@ -13,6 +13,7 @@ const regex = {
 
 const enums = {
   APP_LANG_ENUM: ['en', 'ua'],
+  NATIVE_LANG_ENUM: ['English', 'German', 'Spanish', 'Chinese', 'Portuguese', 'Japanese', 'Ukrainian', 'Arabic', 'French', 'Italian', 'Romanian', 'Japan'],
   SPOKEN_LANG_ENUM: ['English', 'Ukrainian', 'Polish', 'German', 'French', 'Spanish', 'Arabic'],
   PROFICIENCY_LEVEL_ENUM: ['Beginner', 'Intermediate', 'Advanced', 'Test Preparation', 'Professional', 'Specialized'],
   ROLE_ENUM: ['student', 'tutor', 'admin', 'superadmin'],

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,6 +1,6 @@
 const { Schema, model } = require('mongoose')
 const {
-  enums: { APP_LANG_ENUM, SPOKEN_LANG_ENUM, STATUS_ENUM, ROLE_ENUM, LOGIN_ROLE_ENUM }
+  enums: { APP_LANG_ENUM, NATIVE_LANG_ENUM, SPOKEN_LANG_ENUM, STATUS_ENUM, ROLE_ENUM, LOGIN_ROLE_ENUM }
 } = require('~/consts/validation')
 const { SUBJECT, OFFER, USER } = require('~/consts/models')
 const {
@@ -88,8 +88,8 @@ const userSchema = new Schema(
     nativeLanguage: {
       type: String,
       enum: {
-        values: SPOKEN_LANG_ENUM,
-        message: ENUM_CAN_BE_ONE_OF('native language', SPOKEN_LANG_ENUM)
+        values: NATIVE_LANG_ENUM,
+        message: ENUM_CAN_BE_ONE_OF('native language', NATIVE_LANG_ENUM)
       }
     },
     isEmailConfirmed: {
@@ -100,6 +100,11 @@ const userSchema = new Schema(
     isFirstLogin: {
       type: Boolean,
       default: true,
+      select: false
+    },
+    isRegistrationCompleted: {
+      type: Boolean,
+      default: false,
       select: false
     },
     lastLogin: {


### PR DESCRIPTION
### Fixed bug when updating user's native language [ Close #74 ]
The user now receives the expected **success message** and the `native language` is correctly saved in the database.

Fixed the bug that prevented the `native language` from being updated correctly for the `tutor` role:
<img width="1476" alt="Screenshot 2024-05-21 at 15 32 09" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/4deef684-d139-40b2-a3d5-c1df7fa2bdec">

Ensured that the **success message** is displayed and the language data is accurately stored:
<img width="275" alt="Screenshot 2024-05-21 at 15 32 53" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/ba20cff9-cbdd-492c-97db-eebcb4a64dcb">
<img width="564" alt="Screenshot 2024-05-21 at 15 33 08" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/67a012ea-6cb1-45bc-8504-273799f2a2e7">
