### PR TITLE
Extended the user data by incorporating the "spokenLanguages" field #76

### DIFF
--- a/docs/review/review.yaml
+++ b/docs/review/review.yaml
@@ -154,6 +154,7 @@ paths:
                   totalReviews: 10
                   averageRating: 4.5
                   nativeLanguage: english
+                  spokenLanguages: English, Ukrainian
                   address: { country: The USA, city: California }
                   education: KNPU H.S. Skovoroda
                   photo: john-doe-photo.jpg
@@ -252,6 +253,7 @@ paths:
                   totalReviews: 10
                   averageRating: 4.5
                   nativeLanguage: english
+                  spokenLanguages: English, Ukrainian
                   address: { country: The USA, city: California }
                   education: KNPU H.S. Skovoroda
                   photo: john-doe-photo.jpg

--- a/docs/user/user-schema.yaml
+++ b/docs/user/user-schema.yaml
@@ -38,6 +38,8 @@ definitions:
               type: number
         nativeLanguage:
           type: string
+        spokenLanguages:
+          type: array
         address:
           type: object
           properties:
@@ -138,6 +140,8 @@ definitions:
             type: number
       nativeLanguage:
         type: string
+      spokenLanguages:
+        type: array
       address:
         type: object
         properties:

--- a/docs/user/user.yaml
+++ b/docs/user/user.yaml
@@ -62,6 +62,7 @@ paths:
                   totalReviews: { student: 10, tutor: 8 }
                   averageRating: { student: 4.5, tutor: 4.9 }
                   nativeLanguage: english
+                  spokenLanguages: [English, Ukrainian]
                   address: { country: The USA, city: California }
                   professionalSummary: KNPU H.S. Skovoroda
                   photo: john-doe-photo.jpg
@@ -94,6 +95,7 @@ paths:
                   totalReviews: { student: 0, tutor: 530 }
                   averageRating: { student: 0, tutor: 5 }
                   nativeLanguage: ukrainian
+                  spokenLanguages: [English, Ukrainian]
                   address: { country: Ukraine, city: Kharkiv }
                   professionalSummary: KNPU H.S. Skovoroda
                   photo: joe-doe-photo.jpg
@@ -240,6 +242,7 @@ paths:
                   totalReviews: { student: 10, tutor: 0 }
                   averageRating: { student: 4.5, tutor: 0 }
                   nativeLanguage: english
+                  spokenLanguages: [English, Ukrainian]
                   address: { country: The USA, city: California }
                   ProfessionalSummary: KNPU H.S. Skovoroda
                   photo: john-doe-photo.jpg
@@ -282,6 +285,7 @@ paths:
                   totalReviews: { student: 10, tutor: 0 }
                   averageRating: { student: 4.5, tutor: 0 }
                   nativeLanguage: english
+                  spokenLanguages: [English, Ukrainian]
                   address: { country: The USA, city: California }
                   professionalSummary: KNPU H.S. Skovoroda
                   photo: john-doe-photo.jpg

--- a/src/consts/validation.js
+++ b/src/consts/validation.js
@@ -13,7 +13,7 @@ const regex = {
 
 const enums = {
   APP_LANG_ENUM: ['en', 'ua'],
-  SPOKEN_LANG_ENUM: ['English', 'Ukrainian', 'Polish', 'German', 'French', 'Spanish', 'Arabic'],
+  SPOKEN_LANG_ENUM: ['English', 'German', 'Spanish', 'Chinese', 'Portuguese', 'Japanese', 'Ukrainian', 'Arabic', 'French', 'Italian', 'Romanian', 'Japan'],
   PROFICIENCY_LEVEL_ENUM: ['Beginner', 'Intermediate', 'Advanced', 'Test Preparation', 'Professional', 'Specialized'],
   ROLE_ENUM: ['student', 'tutor', 'admin', 'superadmin'],
   LOGIN_ROLE_ENUM: ['student', 'tutor', 'admin'],

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -92,6 +92,13 @@ const userSchema = new Schema(
         message: ENUM_CAN_BE_ONE_OF('native language', SPOKEN_LANG_ENUM)
       }
     },
+    spokenLanguages: {
+      type: [String],
+      enum: {
+        values: SPOKEN_LANG_ENUM,
+        message: ENUM_CAN_BE_ONE_OF('spoken language', SPOKEN_LANG_ENUM)
+      }
+    },
     isEmailConfirmed: {
       type: Boolean,
       default: false,

--- a/src/validation/services/user.js
+++ b/src/validation/services/user.js
@@ -9,6 +9,7 @@ const allowedUserFieldsForUpdate = {
   professionalSummary: true,
   mainSubjects: true,
   nativeLanguage: true,
+  spokenLanguages: true,
   appLanguage: true,
   FAQ: true
 }


### PR DESCRIPTION
### Extended the user data by incorporating the "`spokenLanguages`" field [Close: #76 ]

### Before modification:
<img width="1476" alt="Screenshot 2024-05-21 at 18 14 32" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/142852ee-63af-4ba8-9d7c-4751d3487692">

### After modification:
<img width="1476" alt="Screenshot 2024-05-21 at 18 15 56" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/c896436d-5493-4369-84d3-0322f16930d9">

Also, updated the **Swagger** documentation to reflect the new changes.