### PR TITLE
Added involvement check before updating/deleting Offers #64

### DIFF
--- a/docs/offer/offer.yaml
+++ b/docs/offer/offer.yaml
@@ -168,7 +168,7 @@ paths:
             schema:
               $ref: '#/definitions/offerBody'
             example:
-              price: 300,
+              price: 300
               proficiencyLevel: [Advanced]
               title: this is a new title for test purposes
               description: Lorem ipsum dolor sit amet consectetur
@@ -252,7 +252,7 @@ paths:
                 $ref: '#/definitions/offer'
               example:
                 _id: 63ec1cd51e9d781cdb6f4b14
-                price: 300,
+                price: 300
                 proficiencyLevel: [Advanced]
                 title: this is a new title for test purposes
                 description: Lorem ipsum dolor sit amet consectetur
@@ -357,7 +357,7 @@ paths:
             schema:
               $ref: '#/definitions/offer'
             example:
-              price: 300,
+              price: 300
               proficiencyLevel: [Advanced]
               title: this is a new title for test purposes
               description: this is a test text 123

--- a/src/controllers/offer.js
+++ b/src/controllers/offer.js
@@ -38,8 +38,9 @@ const updateOffer = async (req, res) => {
 
 const deleteOffer = async (req, res) => {
   const { id } = req.params
+  const { id: currentUserId } = req.user
 
-  await offerService.deleteOffer(id)
+  await offerService.deleteOffer(id, currentUserId)
 
   res.status(204).end()
 }

--- a/src/services/offer.js
+++ b/src/services/offer.js
@@ -1,6 +1,7 @@
 const Offer = require('~/models/offer')
 
 const filterAllowedFields = require('~/utils/filterAllowedFields')
+const { createForbiddenError } = require('~/utils/errorsHelper')
 const { allowedOfferFieldsForUpdate } = require('~/validation/services/offer')
 
 const offerService = {
@@ -54,6 +55,10 @@ const offerService = {
 
     const offer = await Offer.findById(id)
 
+    if (offer.author.toString() !== currentUserId) {
+      throw createForbiddenError()
+    }
+
     for (let field in filteredUpdateData) {
       offer[field] = filteredUpdateData[field]
     }
@@ -62,7 +67,13 @@ const offerService = {
     await offer.save()
   },
 
-  deleteOffer: async (id) => {
+  deleteOffer: async (id, currentUserId) => {
+    const offer = await Offer.findById(id).exec()
+
+    if (offer.author.toString() !== currentUserId) {
+      throw createForbiddenError()
+    }
+
     await Offer.findByIdAndRemove(id).exec()
   }
 }


### PR DESCRIPTION
### Added involvement check before updating/deleting `Offers` [ Close #64 ]

**Before changing:**
Users that are not involved in an `offer` (not an author) can `update` or `delete` a document:
<img width="1519" alt="Screenshot 2024-fff05-22 at 15 42 21 (1)" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/f835be66-fcfb-4e0a-a9db-49e5707a0935">

**After changing:**
- [x]  Added involvement check so that if a user is not involved in an `offer` (not the author), they can't `update` or `delete` a document. If they try, a `forbidden error `is thrown:
- On **updating** an offer: 
<img width="1519" alt="Screenshot 2024-05-22 at 15 50 31" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/ad46c310-d37c-4b98-b335-c64f437f0eb4">

- On **deleting** an offer:
<img width="1519" alt="Screenshot 2024-05-22 at 15 53 14" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/cbe7f82e-a459-4b82-adf3-2940ebe2c321">

- [x] Logic of involvement check before updating/deleting Offers **is covered by tests**:
<img width="832" alt="Screenshot 2024-05-22 at 17 37 49" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/95200ac0-ec38-4f23-b01c-e25f33952702">
<img width="741" alt="Screenshot 2024-05-22 at 17 38 36" src="https://github.com/Space2Study-UA-1156/BackEnd-02/assets/28622400/32cc8ca9-c142-4fb3-bf07-64bb01cf90b3">
